### PR TITLE
CLN: Simplify setter validation in filing initialization

### DIFF
--- a/docs/source/whatsnew/v0.2.0.rst
+++ b/docs/source/whatsnew/v0.2.0.rst
@@ -5,6 +5,7 @@ Highlights
 ~~~~~~~~~~
 
 * Removes ``secedgar.crawler.SecCrawler`` class. Use ``secedgar.filings.Filing`` instead.
+* Add ``UserWarning`` when number of downloaded files is less than ``count``.
 
 Contributors
 ~~~~~~~~~~~~

--- a/secedgar/filings/filing.py
+++ b/secedgar/filings/filing.py
@@ -1,6 +1,7 @@
 import datetime
 import os
 import requests
+import warnings
 
 from secedgar.filings._base import AbstractFiling
 from secedgar.client.network_client import NetworkClient
@@ -178,6 +179,11 @@ class Filing(AbstractFiling):
                 break
 
         txt_urls = [link[:link.rfind("-")].strip() + ".txt" for link in links]
+
+        if len(txt_urls) < self.count:
+            warnings.warn("Only {num} of {count} filings were found for {cik}.".format(
+                num=len(txt_urls), count=self.count, cik=cik))
+
         # Takes `count` filings at most
         return txt_urls[:self.count]
 

--- a/secedgar/tests/filings/test_filings.py
+++ b/secedgar/tests/filings/test_filings.py
@@ -240,7 +240,9 @@ class TestFiling(object):
         ]
     )
     @pytest.mark.filterwarnings('ignore::DeprecationWarning')  # For collections.abc warning 3.8+
-    def test_filing_raises_warning_when_less_filings_than_count(self, monkeypatch, recwarn, count, raises_error, tmp_data_directory):
+    def test_filing_raises_warning_when_less_filings_than_count(self, monkeypatch,
+                                                                recwarn, count,
+                                                                raises_error, tmp_data_directory):
         monkeypatch.setattr(_CIKValidator, "get_ciks", MockCIKValidatorGetCIKs.get_ciks)
         monkeypatch.setattr(NetworkClient, "get_response", MockSingleCIKFilingLimitedResponses(10))
         f = Filing(cik_lookup=['aapl', 'msft', 'amzn'], filing_type=FilingType.FILING_10Q,
@@ -253,5 +255,6 @@ class TestFiling(object):
             try:
                 w = recwarn.pop(UserWarning)
                 pytest.fail("Expected no UserWarning, but received one.")
-            except AssertionError:  # Should raise assertion error since no UserWarning should be found
+            # Should raise assertion error since no UserWarning should be found
+            except AssertionError:
                 pass

--- a/secedgar/utils/exceptions.py
+++ b/secedgar/utils/exceptions.py
@@ -1,36 +1,18 @@
 class EDGARQueryError(Exception):
     """This error is thrown when a query receives a response that is not a 200 response."""
-
-    def __str__(self):  # pragma: no cover
-        return "An error occured while making the query."
+    pass
 
 
 class EDGARFieldError(Exception):
     """This error is thrown when an invalid field is given to an endpoint."""
-
-    def __init__(self, endpoint, field):  # pragma: no cover
-        self.endpoint = endpoint
-        self.field = field
-
-    def __str__(self):  # pragma: no cover
-        return "Field {field} not found in endpoint {endpoint}".format(
-            field=self.field, endpoint=self.endpoint
-        )
+    pass
 
 
 class CIKError(Exception):
     """This error is thrown when an invalid CIK is given."""
-
-    def __init__(self, cik):
-        self.cik = cik
-
-    def __str__(self):  # pragma: no cover
-        return "CIK {cik} not valid.".format(cik=self.cik)
+    pass
 
 
 class FilingTypeError(Exception):
     """This error is thrown when an invalid filing type is given."""
-
-    def __str__(self):  # pragma: no cover
-        return "The filing type given is not valid. " \
-               "Filing type must be in valid filing type from FilingType class"
+    pass


### PR DESCRIPTION
Keep it DRY by relying on setters for validation and add warning if number of filings is less than `count`.

- [x] closes #124 
- [x] tests added
- [x] Add to whatsnew