### PR TITLE
Add user_agent arg to NetworkClient

### DIFF
--- a/docs/source/filings.rst
+++ b/docs/source/filings.rst
@@ -58,6 +58,21 @@ You can also look up a specific filing type for multiple companies.
 
 *For a full list of the available filing types, please see* :class:`secedgar.filings.FilingType`.
 
+
+SEC requests that traffic identifies itself via a user agent string. You can
+customize this according to your preference using the ``user_agent`` argument.
+
+.. code-block:: python
+
+   from secedgar.filings import FilingType, Filing
+   from datetime import datetime
+
+   filing = Filing(cik_lookup=['aapl', 'msft', 'fb'],
+                   filing_type=FilingType.FILING_10K,
+                   start_date=datetime(2015, 1, 1),
+                   user_agent='YOUR COMPANY NAME HERE')
+
+
 Daily Filings
 -------------
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -35,6 +35,19 @@ The ``cik_lookup`` argument can also take multiple tickers and/or company names.
                        count=15)
 
 
+SEC requests that traffic identifies itself via a user agent string. You can
+customize this according to your preference using the ``user_agent`` argument.
+
+.. code-block:: python
+
+   from secedgar.filings import Filing, FilingType
+
+   my_filings = Filing(cik_lookup=['aapl', 'msft', 'Facebook'],
+                       filing_type=FilingType.FILING_10Q,
+                       count=15,
+                       user_agent='YOUR COMPANY NAME HERE')
+
+
 In order to save all fetched filings to a specific directory, use the ``save`` method.
 
 .. code-block:: python

--- a/docs/source/whatsnew/v0.3.3.rst
+++ b/docs/source/whatsnew/v0.3.3.rst
@@ -1,0 +1,15 @@
+v0.3.3
+------
+
+Highlights
+~~~~~~~~~~
+
+- Add ``user_agent`` argument to ``NetworkClient``
+
+
+Contributors
+~~~~~~~~~~~~
+
+- kevinschaul
+- jackmoody11
+

--- a/secedgar/client/network_client.py
+++ b/secedgar/client/network_client.py
@@ -99,7 +99,7 @@ class NetworkClient:
 
     @property
     def user_agent(self):
-        """str: Value used for HTTP header "User-Agent" for all requests"""
+        """str: Value used for HTTP header "User-Agent" for all requests."""
         return self._user_agent
 
     @user_agent.setter

--- a/secedgar/client/network_client.py
+++ b/secedgar/client/network_client.py
@@ -35,7 +35,12 @@ class NetworkClient:
 
     _BASE = "http://www.sec.gov/"
 
-    def __init__(self, retry_count=3, batch_size=10, backoff_factor=0, rate_limit=10, user_agent="github.com/sec-edgar/sec-edgar"):
+    def __init__(self,
+                 retry_count=3,
+                 batch_size=10,
+                 backoff_factor=0,
+                 rate_limit=10,
+                 user_agent="github.com/sec-edgar/sec-edgar"):
         self.retry_count = retry_count
         self.batch_size = batch_size
         self.backoff_factor = backoff_factor
@@ -164,7 +169,7 @@ class NetworkClient:
             session.mount(self._BASE, adapter=HTTPAdapter(max_retries=retry))
             session.hooks["response"].append(self._validate_response)
             response = session.get(prepared_url, params=params,
-                          headers=headers, **kwargs)
+                                   headers=headers, **kwargs)
             return response
 
     def get_soup(self, path, params, **kwargs):

--- a/secedgar/client/network_client.py
+++ b/secedgar/client/network_client.py
@@ -162,7 +162,7 @@ class NetworkClient:
             EDGARQueryError: If problems arise when making query.
         """
         prepared_url = self._prepare_query(path)
-        headers = {"user-agent": self.user_agent}
+        headers = {"User-Agent": self.user_agent}
         with requests.Session() as session:
             retry = Retry(self.retry_count, backoff_factor=self.backoff_factor,
                           raise_on_status=True)

--- a/secedgar/filings/filing.py
+++ b/secedgar/filings/filing.py
@@ -47,11 +47,11 @@ class Filing(AbstractFiling):
         self.start_date = start_date
         self.end_date = end_date
         self.filing_type = filing_type
-        # make CIKLookup object for users if not given
-        self.cik_lookup = cik_lookup
         self.count = count
         # Make default client NetworkClient and pass in kwargs
         self._client = client if client is not None else NetworkClient(**kwargs)
+        # make CIKLookup object for users if not given
+        self.cik_lookup = cik_lookup
 
     @property
     def path(self):
@@ -128,7 +128,7 @@ class Filing(AbstractFiling):
     @cik_lookup.setter
     def cik_lookup(self, val):
         if not isinstance(val, CIKLookup):
-            val = CIKLookup(val)
+            val = CIKLookup(val, client=self.client)
         self._cik_lookup = val
 
     def get_urls(self, **kwargs):

--- a/secedgar/filings/filing.py
+++ b/secedgar/filings/filing.py
@@ -24,6 +24,8 @@ class Filing(AbstractFiling):
             Stands for "date before." Defaults to today.
         count (int): Number of filings to fetch. Will fetch up to `count` if that many filings
             are available. Defaults to all filings available.
+        user_agent (str): Value used for HTTP header "User-Agent" for all requests.
+            Defaults to "github.com/sec-edgar/sec-edgar"
         kwargs: See kwargs accepted for :class:`secedgar.client.network_client.NetworkClient`.
 
     .. versionadded:: 0.1.5


### PR DESCRIPTION
SEC is asking users to declare their traffic "by updating your user agent to include company specific information." This seems to be a relatively new change.

This PR sets the default user-agent header to `github.com/sec-edgar/sec-edgar`. It allows users to customize it by adding the argument `user_agent` to the `Filing` and `CIKLookup` classes.

This may help with recent issues including #190 #192 #193. See also #194.

I need to get the tests code working and flake8 etc. to make this a clean PR. In the meantime I appreciate any feedback on whether this strategy makes sense. Thanks!

- [ ] closes #xxxx
- [ ] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] added entry to docs/whatsnew latest version