### PR TITLE
Bypass CIK lookup calls if argument is already CIK

### DIFF
--- a/docs/source/whatsnew/v0.3.3.rst
+++ b/docs/source/whatsnew/v0.3.3.rst
@@ -1,0 +1,15 @@
+v0.3.3
+------
+
+Highlights
+~~~~~~~~~~
+
+- Bypasses CIK lookup calls to SEC if the provided argument is already a CIK.
+
+
+Contributors
+~~~~~~~~~~~~
+
+- kevinschaul
+- jackmoody11
+

--- a/secedgar/cik_lookup.py
+++ b/secedgar/cik_lookup.py
@@ -187,23 +187,28 @@ class CIKLookup:
         ciks = {}
         to_lookup = set(self.lookups)
 
-        cik_map = get_cik_map()
+        # If the lookup is all CIKs already, don't bother looking them up
+        if all([s.isdigit() for s in to_lookup]):
+            for lookup in to_lookup:
+                ciks[lookup] = lookup
+        else:
+            cik_map = get_cik_map()
 
-        # all keys upper case
-        ticker_map = cik_map["ticker"]
-        title_map = cik_map["title"]
+            # all keys upper case
+            ticker_map = cik_map["ticker"]
+            title_map = cik_map["title"]
 
-        for lookup in to_lookup:
-            lookup_norm = lookup.upper()
-            if lookup_norm in ticker_map:
-                ciks[lookup] = ticker_map[lookup_norm]
-            elif lookup_norm in title_map:
-                ciks[lookup] = title_map[lookup_norm]
-            else:
-                try:
-                    result = self._get_cik_from_html(lookup)
-                    self._validate_cik(result)  # raises CIKError if not valid CIK
-                    ciks[lookup] = result
-                except CIKError:
-                    pass  # If multiple companies, found, print out warnings and skip
+            for lookup in to_lookup:
+                lookup_norm = lookup.upper()
+                if lookup_norm in ticker_map:
+                    ciks[lookup] = ticker_map[lookup_norm]
+                elif lookup_norm in title_map:
+                    ciks[lookup] = title_map[lookup_norm]
+                else:
+                    try:
+                        result = self._get_cik_from_html(lookup)
+                        self._validate_cik(result)  # raises CIKError if not valid CIK
+                        ciks[lookup] = result
+                    except CIKError:
+                        pass  # If multiple companies, found, print out warnings and skip
         return ciks

--- a/secedgar/cik_lookup.py
+++ b/secedgar/cik_lookup.py
@@ -187,28 +187,25 @@ class CIKLookup:
         ciks = {}
         to_lookup = set(self.lookups)
 
-        # If the lookup is all CIKs already, don't bother looking them up
-        if all([s.isdigit() for s in to_lookup]):
-            for lookup in to_lookup:
+        cik_map = get_cik_map()
+
+        # all keys upper case
+        ticker_map = cik_map["ticker"]
+        title_map = cik_map["title"]
+
+        for lookup in to_lookup:
+            lookup_norm = lookup.upper()
+            if lookup_norm.isdigit():
                 ciks[lookup] = lookup
-        else:
-            cik_map = get_cik_map()
-
-            # all keys upper case
-            ticker_map = cik_map["ticker"]
-            title_map = cik_map["title"]
-
-            for lookup in to_lookup:
-                lookup_norm = lookup.upper()
-                if lookup_norm in ticker_map:
-                    ciks[lookup] = ticker_map[lookup_norm]
-                elif lookup_norm in title_map:
-                    ciks[lookup] = title_map[lookup_norm]
-                else:
-                    try:
-                        result = self._get_cik_from_html(lookup)
-                        self._validate_cik(result)  # raises CIKError if not valid CIK
-                        ciks[lookup] = result
-                    except CIKError:
-                        pass  # If multiple companies, found, print out warnings and skip
+            elif lookup_norm in ticker_map:
+                ciks[lookup] = ticker_map[lookup_norm]
+            elif lookup_norm in title_map:
+                ciks[lookup] = title_map[lookup_norm]
+            else:
+                try:
+                    result = self._get_cik_from_html(lookup)
+                    self._validate_cik(result)  # raises CIKError if not valid CIK
+                    ciks[lookup] = result
+                except CIKError:
+                    pass  # If multiple companies, found, print out warnings and skip
         return ciks


### PR DESCRIPTION
See #194

- [ ] closes #xxxx
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] added entry to docs/whatsnew latest version