### PR TITLE
Fix user agent in NetworkClient

### DIFF
--- a/secedgar/client.py
+++ b/secedgar/client.py
@@ -236,11 +236,6 @@ class NetworkClient:
             for ndx in range(0, length, n):
                 yield iterable[ndx:min(ndx + n, length)]
 
-        conn = aiohttp.TCPConnector(limit=self.rate_limit)
-        client = aiohttp.ClientSession(connector=conn,
-                                       headers={'Connection': 'keep-alive'},
-                                       raise_for_status=True)
-
         async with client:
             for group in tqdm.tqdm(batch(inputs, self.rate_limit),
                                    total=len(inputs) // self.rate_limit,


### PR DESCRIPTION
- [x] closes #220 
- [x] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] added entry to docs/whatsnew latest version

This duplicated block of code re-initializes the `ClientSession` without the user agent header, removing it fixes the 403 behavior.