### PR TITLE
Fix #277: add missing user_agent to ComboFilings

### DIFF
--- a/docs/source/whatsnew/v0.4.1.rst
+++ b/docs/source/whatsnew/v0.4.1.rst
@@ -4,7 +4,7 @@ v0.4.1
 Highlights
 ~~~~~~~~~~
 
-- Fixes issue with ``QuarterlyFilings`` not setting ``user_agent`` argument. Thanks to prhiggins!
+- Fixes issue with ``ComboFilings`` not setting ``user_agent`` argument. Thanks to prhiggins!
 
 Contributors
 ~~~~~~~~~~~~

--- a/docs/source/whatsnew/v0.4.1.rst
+++ b/docs/source/whatsnew/v0.4.1.rst
@@ -1,0 +1,13 @@
+v0.4.1
+------
+
+Highlights
+~~~~~~~~~~
+
+- Fixes issue with ``QuarterlyFilings`` not setting ``user_agent`` argument. Thanks to prhiggins!
+
+Contributors
+~~~~~~~~~~~~
+
+- prhiggins
+- jackmoody11

--- a/secedgar/core/_base.py
+++ b/secedgar/core/_base.py
@@ -90,12 +90,12 @@ class AbstractFiling(ABC):
         return stripped.replace(" ", "_")
 
     def get_urls_safely(self, **kwargs):
-        """Wrapper around `get_urls` to check if there is a positive number of URLs, and warn if they don't.
+        """Wrapper around `get_urls` to check if there is a positive number of URLs.
 
         .. note:: This method will not check if the URLs are valid. Simply if they exist.
 
         Raises:
-            NoFilingsError: If no URLs exist, then NoFilingsError is raised.
+            ``NoFilingsError``: If no URLs exist, then NoFilingsError is raised.
 
         Returns:
             urls (dict): Result of `get_urls` method.

--- a/secedgar/core/_index.py
+++ b/secedgar/core/_index.py
@@ -162,6 +162,7 @@ class IndexFilings(AbstractFiling):
                              idx_file, re.MULTILINE)
         for entry in entries:
             fields = entry.split("|")
+            fields[-1] = fields[-1].strip()  # get rid of carriage return or newline
             path = "Archives/{file_name}".format(file_name=fields[-1])
             entry = FilingEntry(*fields,
                                 path=path,

--- a/secedgar/core/combo.py
+++ b/secedgar/core/combo.py
@@ -84,6 +84,7 @@ class ComboFilings:
         self.entry_filter = entry_filter
         self.start_date = start_date
         self.end_date = end_date
+        self.user_agent = user_agent
         self._client = client or NetworkClient(user_agent=user_agent, **kwargs)
         self._balancing_point = balancing_point
 

--- a/secedgar/tests/core/test_combo.py
+++ b/secedgar/tests/core/test_combo.py
@@ -191,3 +191,8 @@ class TestComboFilings:
         assert len(quarter_list) == 1, "Should only have one quarter"
         assert quarter_list[0][0] == 2022, "Only quarter in list should be Q1 2022"
         assert quarter_list[0][1] == 1, "Only quarter in list should be Q1 2022"
+
+    def test_combo_no_user_agent_raises_error(self):
+        with pytest.raises(TypeError):
+            _ = ComboFilings(start_date=date(2022, 2, 28),
+                             end_date=date(2022, 4, 15))

--- a/secedgar/tests/core/test_quarterly.py
+++ b/secedgar/tests/core/test_quarterly.py
@@ -104,3 +104,7 @@ class TestQuarterly:
     def test_user_agent_passed_to_client(self, mock_user_agent):
         quarterly = QuarterlyFilings(year=2020, quarter=1, user_agent=mock_user_agent)
         assert quarterly.client.user_agent == mock_user_agent
+
+    def test_error_raised_no_user_agent(self):
+        with pytest.raises(TypeError):
+            quarterly = QuarterlyFilings(year=2020, quarter=1)

--- a/secedgar/tests/core/test_quarterly.py
+++ b/secedgar/tests/core/test_quarterly.py
@@ -107,4 +107,4 @@ class TestQuarterly:
 
     def test_error_raised_no_user_agent(self):
         with pytest.raises(TypeError):
-            quarterly = QuarterlyFilings(year=2020, quarter=1)
+            _ = QuarterlyFilings(year=2020, quarter=1)


### PR DESCRIPTION
Stumbled upon the issue described in #277 and needed a fix, which I implemented in the manner proposed in the original issue post by adding a likely missing `self.user_agent = user_agent`.

- [x] Fixes #277
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] added entry to docs/whatsnew latest version