### PR TITLE
Pass user agent to CIK lookup

### DIFF
--- a/secedgar/cik_lookup.py
+++ b/secedgar/cik_lookup.py
@@ -8,7 +8,7 @@ from secedgar.exceptions import CIKError, EDGARQueryError
 
 
 @functools.lru_cache()
-def get_cik_map(user_agent=None):
+def get_cik_map(user_agent):
     """Get dictionary of tickers and company names to CIK numbers.
 
     Uses ``functools.lru_cache`` to cache response if used in later calls.
@@ -29,10 +29,7 @@ def get_cik_map(user_agent=None):
 
     .. versionadded:: 0.1.6
     """
-    if user_agent:
-        headers = {'user-agent': user_agent}
-    else:
-        headers = {}
+    headers = {'user-agent': user_agent}
     response = requests.get("https://www.sec.gov/files/company_tickers.json", headers=headers)
     json_response = response.json()
     return {key: {v[key].upper(): str(v["cik_str"]) for v in json_response.values()

--- a/secedgar/cik_lookup.py
+++ b/secedgar/cik_lookup.py
@@ -8,7 +8,7 @@ from secedgar.exceptions import CIKError, EDGARQueryError
 
 
 @functools.lru_cache()
-def get_cik_map():
+def get_cik_map(user_agent=None):
     """Get dictionary of tickers and company names to CIK numbers.
 
     Uses ``functools.lru_cache`` to cache response if used in later calls.
@@ -29,7 +29,11 @@ def get_cik_map():
 
     .. versionadded:: 0.1.6
     """
-    response = requests.get("https://www.sec.gov/files/company_tickers.json")
+    if user_agent:
+        headers = {'user-agent': user_agent}
+    else:
+        headers = {}
+    response = requests.get("https://www.sec.gov/files/company_tickers.json", headers=headers)
     json_response = response.json()
     return {key: {v[key].upper(): str(v["cik_str"]) for v in json_response.values()
                   if v[key] is not None}
@@ -201,7 +205,7 @@ class CIKLookup:
         ciks = {}
         to_lookup = set(self.lookups)
 
-        cik_map = get_cik_map()
+        cik_map = get_cik_map(self.client.user_agent)
 
         # all keys upper case
         ticker_map = cik_map["ticker"]


### PR DESCRIPTION
Fix the CIK lookup to pass user agent when provided by the user. Without this change the SEC EDGAR web server blocks the default python-requests user agent.

- [ ] closes #296
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] added entry to docs/whatsnew latest version