### PR TITLE
Fix tests for SEC API wrapper

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,10 +16,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           persist-credentials: false
-      - name: Set up Python 3.6
+      - name: Set up Python 3.8
         uses: actions/setup-python@v4
         with:
-          python-version: 3.6
+          python-version: 3.8
       - name: Install dependencies
         run: |
           ./ci/install_dependencies.sh docs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v3

--- a/ci/install_dependencies.sh
+++ b/ci/install_dependencies.sh
@@ -9,7 +9,7 @@
 #     $ ./ci/install_dependencies.sh pypi # set up dependencies for deploying to PyPi
 if [[ $(uname) == "Linux" ]]; then
     # Install lxml dependencies
-    sudo apt-get update && sudo apt-get install python-dev libxml2-dev libxslt-dev libz-dev
+    sudo apt-get update && sudo apt-get install python-dev libxml2-dev libxslt-dev libz-dev python3-setuptools
 fi
 
 # Both dev and docs dependencies require dev dependencies

--- a/secedgar/core/filings.py
+++ b/secedgar/core/filings.py
@@ -151,7 +151,7 @@ def filings(
 
     if filing_type is not None:
         # If filing type also given, add filing types to existing entry filter
-        def _entry_filter(x):
+        def _entry_filter(x):  # noqa: F811
             return x.form_type == filing_type and entry_filter(x)
 
     if count is not None:

--- a/secedgar/tests/conftest.py
+++ b/secedgar/tests/conftest.py
@@ -80,7 +80,8 @@ def tmp_data_directory(tmpdir_factory):
 def mock_cik_validator_get_multiple_ciks(monkeysession):
     """Mocks response for getting a single CIK."""
     monkeysession.setattr(CIKLookup, "get_ciks",
-                          lambda *args: {"aapl": "0000320193", "msft": "0000789019", "amzn": "0001018724"})
+                          lambda *args: {"aapl": "0000320193", "msft": "0000789019",
+                                         "amzn": "0001018724"})
 
 
 @pytest.fixture(scope="session")

--- a/secedgar/tests/conftest.py
+++ b/secedgar/tests/conftest.py
@@ -80,7 +80,7 @@ def tmp_data_directory(tmpdir_factory):
 def mock_cik_validator_get_multiple_ciks(monkeysession):
     """Mocks response for getting a single CIK."""
     monkeysession.setattr(CIKLookup, "get_ciks",
-                          lambda *args: {"aapl": "0000320193", "msft": "1234", "amzn": "5678"})
+                          lambda *args: {"aapl": "0000320193", "msft": "0000789019", "amzn": "0001018724"})
 
 
 @pytest.fixture(scope="session")

--- a/secedgar/tests/core/test_rest.py
+++ b/secedgar/tests/core/test_rest.py
@@ -43,15 +43,15 @@ class TestRest:
     @pytest.mark.smoke
     def test_get_company_concepts(self, mock_user_agent):
         concept = "AccountsPayableCurrent"
-        concepts = get_company_concepts(lookups=["AAPL"],
+        concepts = get_company_concepts(lookups=["aapl"],
                                         user_agent=mock_user_agent,
                                         concept_name=concept)
         assert concepts
         # Ensure CIK is correct
-        assert str(concepts["AAPL"]["cik"]) == "320193"
+        assert str(concepts["aapl"]["cik"]) == "320193"
 
         # Make sure that there are results for accounts payable
-        assert concepts["AAPL"]["units"]["USD"]
+        assert concepts["aapl"]["units"]["USD"]
 
         # Result should be dictionary
         assert isinstance(concepts, dict)


### PR DESCRIPTION
Update the mock CIK lookup fixture used by Pytest. The original mock values for MSFT and AMZN do not match the real data. Fix casing on the JSON return data.

- [ ] closes #298
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] added entry to docs/whatsnew latest version

Successful test:

```
$ pytest
======================================================================== test session starts =========================================================================
rootdir: /sec-edgar
configfile: setup.cfg
collected 486 items                                                                                                                                                  

tests/test_cik_lookup.py ..................................................                                                                                    [ 10%]
tests/test_cli.py ..............                                                                                                                               [ 13%]
tests/test_client.py ................................................................................                                                          [ 29%]
tests/test_exceptions.py ...                                                                                                                                   [ 30%]
tests/test_parser.py .......                                                                                                                                   [ 31%]
tests/test_utils.py ..................................................                                                                                         [ 41%]
tests/core/test_combo.py ...........................                                                                                                           [ 47%]
tests/core/test_company.py .........................................................................................................                           [ 69%]
tests/core/test_daily.py ...............................................................................................                                       [ 88%]
tests/core/test_filings.py ..............                                                                                                                      [ 91%]
tests/core/test_quarterly.py ................................                                                                                                  [ 98%]
tests/core/test_rest.py .........                                                                                                                              [100%]
============================================================ 486 passed, 17 warnings in 85.55s (0:01:25) =============================================================
```