### PR TITLE
Tested the old syntax

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ You can clone the project:
 
    $ git clone https://github.com/sec-edgar/sec-edgar.git
    $ cd sec-edgar
-   $ python setup.py install
+   $ python install .
 
 Running
 -------


### PR DESCRIPTION
`python setup.py install` doesn't work.

Replaced with `python install .`, which matches documentation, and does work.
