### PR TITLE
Fix readme pip installation instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ You can install the package using pip:
 
 .. code:: bash
 
-   $ pip install secedgar
+   $ pip install git+https://github.com/sec-edgar/sec-edgar.git
 
 OR
 


### PR DESCRIPTION
`$ pip install secedgar`

changed to 

`$ pip install git+https://github.com/sec-edgar/sec-edgar.git`

So people don't install an old, non-working version. 