### PR TITLE
Update ciklookup.rst

### DIFF
--- a/docs/source/ciklookup.rst
+++ b/docs/source/ciklookup.rst
@@ -12,7 +12,7 @@ Below is an example of how you can retrieve lookup CIKs by using the ``CIKLookup
 
 .. code-block:: python
 
-   from secedgar.core.cik_lookup import CIKLookup
+   from secedgar.cik_lookup import CIKLookup
 
    lookups = CIKLookup(['aapl', 'msft', 'Facebook'],
                        user_agent="Name (email)")


### PR DESCRIPTION
The path of the class is not right.

Upon using the example, it is getting "ModuleNotFoundError: No module named'secedgar.core.cik_lookup'"